### PR TITLE
Add error code to unrecognised error message

### DIFF
--- a/build/errors.js
+++ b/build/errors.js
@@ -53,9 +53,19 @@ messages = require('./messages');
  */
 
 exports.interpret = function(error) {
-  var _ref;
+  var message, _ref;
   if (!(error instanceof Error)) {
     return;
   }
-  return ((_ref = messages[error.code]) != null ? _ref.call(messages, error) : void 0) || error.message || void 0;
+  message = (_ref = messages[error.code]) != null ? _ref.call(messages, error) : void 0;
+  if (message != null) {
+    return message;
+  }
+  if (!_.isEmpty(error.message)) {
+    if (error.code != null) {
+      return "" + error.code + ": " + error.message;
+    } else {
+      return error.message;
+    }
+  }
 };

--- a/lib/errors.coffee
+++ b/lib/errors.coffee
@@ -49,4 +49,11 @@ messages = require('./messages')
 ###
 exports.interpret = (error) ->
 	return if error not instanceof Error
-	return messages[error.code]?.call(messages, error) or error.message or undefined
+	message = messages[error.code]?.call(messages, error)
+	return message if message?
+
+	if not _.isEmpty(error.message)
+		if error.code?
+			return "#{error.code}: #{error.message}"
+		else
+			return error.message

--- a/tests/errors.spec.coffee
+++ b/tests/errors.spec.coffee
@@ -112,6 +112,13 @@ describe 'Errors:', ->
 			message = errors.interpret(error)
 			m.chai.expect(message).to.equal('Hello World')
 
+		it 'should return the message along with the code given a non recognised error', ->
+			error = new Error()
+			error.message = 'Hello World'
+			error.code = 'EFOO'
+			message = errors.interpret(error)
+			m.chai.expect(message).to.equal('EFOO: Hello World')
+
 	describe 'given invalid inputs', ->
 
 		it 'should return undefined if object is not an instance of Error', ->


### PR DESCRIPTION
From time to time, we get an error that is not recognised by our
messages object, in which case, only the message is returned.

This means that if we want to add a new message rule for that specific
type of error, we must reproduce the error with `DEBUG=true` to get it's
code. Also notice that some one-time errors are very hard to reproduce.

For this reason, this module now returns the error code along with the
error message when the error is not recognised.
