### PR TITLE
Deprecate module, as it's now built into the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.1] - 2018-05-03
+
+- Deprecate module, as it's now built into the CLI
+
 ## [1.2.0] - 2016-03-03
 
 - Provide a friendly error message for `ResinExpiredToken`.
@@ -27,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Handle locked SDCard case in EPERM/EACCES.
 
+[1.2.1]: https://github.com/resin-io-modules/resin-cli-errors/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/resin-io-modules/resin-cli-errors/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/resin-io-modules/resin-cli-errors/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/resin-io-modules/resin-cli-errors/compare/v1.0.2...v1.1.0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.p
 
 Resin.io CLI error interpreter.
 
+This package is now deprecated
+====
+
+Resin-cli-errors is now built into [Resin CLI](https://github.com/resin-io/resin-cli) itself, so this package is not maintained, and should not be used.
+
 Role
 ----
 

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -10,6 +10,11 @@ Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.p
 
 Resin.io CLI error interpreter.
 
+This package is now deprecated
+====
+
+Resin-cli-errors is now built into [Resin CLI](https://github.com/resin-io/resin-cli) itself, so this package is not maintained, and should not be used.
+
 Role
 ----
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resin-cli-errors",
   "version": "1.2.0",
-  "description": "Resin.io CLI error interpreter",
+  "description": "DEPRECATED - Resin.io CLI error interpreter",
   "main": "build/errors.js",
   "homepage": "https://github.com/resin-io-modules/resin-cli-errors",
   "repository": {


### PR DESCRIPTION
Depends on https://github.com/resin-io/resin-cli/pull/874.

After this is merged, the package should be deprecated in NPM itself.